### PR TITLE
Fix Duplicate Partition Context in State File

### DIFF
--- a/tap_sparkthink/client.py
+++ b/tap_sparkthink/client.py
@@ -78,10 +78,14 @@ class ProjectBasedStream(sparkthinkStream):
         """Return a dictionary of values for each query variable
 
         """
-        if next_page_token:
-            context['cursor'] = next_page_token
+        params: dict = {}
         
-        return context or {}
+        params.update(context) # grab values already set in context (project_id, response_batch_size)
+
+        if next_page_token:
+            params['cursor'] = next_page_token
+        
+        return params
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
         """As needed, append or transform raw data to match expected structure."""


### PR DESCRIPTION
Updates get_url_params to return a new dict instead of modifying the context dict - the context dict keys should match the keys defined in the partitions list property.

Borrowed this pattern from the tap-gitlab sample code:
https://gitlab.com/meltano/sdk/-/blob/main/singer_sdk/samples/sample_tap_gitlab/gitlab_rest_streams.py#L41