### PR TITLE
Add collectorId to response stream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-sparkthink"
-version = "0.0.5"
+version = "0.0.6"
 description = "`tap-sparkthink` is a Singer tap for sparkthink, built with the Meltano SDK for Singer Taps."
 authors = ["John Timeus"]
 license = "Apache 2.0"

--- a/tap_sparkthink/streams.py
+++ b/tap_sparkthink/streams.py
@@ -333,6 +333,7 @@ class ResponsesStream(ProjectBasedStream):
             )
         ),
         th.Property("questionId", th.StringType),
+        th.Property("collectorId", th.StringType),
         th.Property(
             "NestedOptionResponseOptions",
             th.ArrayType(
@@ -404,6 +405,7 @@ class ResponsesStream(ProjectBasedStream):
                                             lastModifiedUTC
                                         }
                                         questionId
+                                        collectorId
                                         ... on NestedOptionResponse {
                                             NestedOptionResponseOptions: options {
                                                 id


### PR DESCRIPTION
Add collectorId to response stream so that a Project - User - Collector combination from the respondent stream can be joined to a Project - User - Collector combination from the response stream for accurate reporting